### PR TITLE
Dynamic AST generator

### DIFF
--- a/ast/Stmt.go
+++ b/ast/Stmt.go
@@ -3,21 +3,21 @@ package ast
 import "dsoechting/glox/token"
 
 type Stmt interface {
-	Accept(visitor StmtVisitor) (any, error)
+	Accept(visitor StmtVisitor) error
 }
 
 type StmtVisitor interface {
-	VisitBlock(stmt *BlockStmt) (any, error)
-	VisitExpression(stmt *ExpressionStmt) (any, error)
-	VisitPrint(stmt *PrintStmt) (any, error)
-	VisitVar(stmt *VarStmt) (any, error)
+	VisitBlock(stmt *BlockStmt) error
+	VisitExpression(stmt *ExpressionStmt) error
+	VisitPrint(stmt *PrintStmt) error
+	VisitVar(stmt *VarStmt) error
 }
 
 type BlockStmt struct {
 	Statements []Stmt
 }
 
-func (e *BlockStmt) Accept(visitor StmtVisitor) (any, error) {
+func (e *BlockStmt) Accept(visitor StmtVisitor) error {
 	return visitor.VisitBlock(e)
 }
 
@@ -25,7 +25,7 @@ type ExpressionStmt struct {
 	Expression Expr
 }
 
-func (e *ExpressionStmt) Accept(visitor StmtVisitor) (any, error) {
+func (e *ExpressionStmt) Accept(visitor StmtVisitor) error {
 	return visitor.VisitExpression(e)
 }
 
@@ -33,7 +33,7 @@ type PrintStmt struct {
 	Expression Expr
 }
 
-func (e *PrintStmt) Accept(visitor StmtVisitor) (any, error) {
+func (e *PrintStmt) Accept(visitor StmtVisitor) error {
 	return visitor.VisitPrint(e)
 }
 
@@ -42,6 +42,6 @@ type VarStmt struct {
 	Initializer Expr
 }
 
-func (e *VarStmt) Accept(visitor StmtVisitor) (any, error) {
+func (e *VarStmt) Accept(visitor StmtVisitor) error {
 	return visitor.VisitVar(e)
 }

--- a/interpret/Interpreter.go
+++ b/interpret/Interpreter.go
@@ -50,31 +50,31 @@ func (i *Interpreter) Interpret(statements []Stmt) (string, error) {
 	return "", nil
 }
 
-func (i *Interpreter) VisitExpression(stmt *ExpressionStmt) (any, error) {
+func (i *Interpreter) VisitExpression(stmt *ExpressionStmt) error {
 	_, err := i.evaluate(stmt.Expression)
-	return nil, err
+	return err
 }
 
-func (i *Interpreter) VisitPrint(stmt *PrintStmt) (any, error) {
+func (i *Interpreter) VisitPrint(stmt *PrintStmt) error {
 	value, err := i.evaluate(stmt.Expression)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	fmt.Println(stringify(value))
-	return nil, nil
+	return nil
 }
 
-func (i *Interpreter) VisitVar(stmt *VarStmt) (any, error) {
+func (i *Interpreter) VisitVar(stmt *VarStmt) error {
 	var value any
 	var err error
 	if stmt.Initializer != nil {
 		value, err = i.evaluate(stmt.Initializer)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 	i.environment.Define(stmt.Name.Lexeme, value)
-	return nil, nil
+	return nil
 }
 
 func (i *Interpreter) VisitTernary(expr *TernaryExpr) (any, error) {
@@ -227,14 +227,14 @@ func (i *Interpreter) evaluate(expr Expr) (any, error) {
 }
 
 func (i *Interpreter) execute(stmt Stmt) error {
-	_, err := stmt.Accept(i)
+	err := stmt.Accept(i)
 	return err
 }
 
-func (i *Interpreter) VisitBlock(stmt *BlockStmt) (any, error) {
+func (i *Interpreter) VisitBlock(stmt *BlockStmt) error {
 	blockEnv := environment.CreateWithEnclosing(i.environment)
 	i.executeBlock(stmt.Statements, blockEnv)
-	return nil, nil
+	return nil
 }
 
 // I hope that we don't run in to any nil here

--- a/main.go
+++ b/main.go
@@ -76,15 +76,9 @@ func (g *Glox) run(source string) {
 		g.setCompileError(scanErr)
 		return
 	}
+	// scanner.PrintTokens()
 
-	// Token printing code
-	// for _, token := range tokens {
-	// 	log.Println(token)
-	// }
-
-	// printer := AstPrinter{}
 	parser := parse.Create(tokens)
-	// We need to make this static in the future, I am just hacking this in for now
 
 	statements, parseError := parser.Parse()
 	if parseError != nil {

--- a/scanner/Scanner.go
+++ b/scanner/Scanner.go
@@ -4,6 +4,7 @@ import (
 	"dsoechting/glox/error"
 	"dsoechting/glox/token"
 	"fmt"
+	"log"
 	"strconv"
 )
 
@@ -256,4 +257,10 @@ func (s *Scanner) addToken(tokenType token.TokenType, literal any) {
 	text := s.source[s.start:s.current]
 	newToken := token.Create(tokenType, text, literal, s.line)
 	s.tokens = append(s.tokens, *newToken)
+}
+
+func (s *Scanner) PrintTokens() {
+	for _, token := range s.tokens {
+		log.Println(token)
+	}
 }

--- a/temp.glox
+++ b/temp.glox
@@ -1,6 +1,7 @@
 var a = "global a";
 var b = "global b";
 var c = "global c";
+var d = 4 > 5 ? "t" : "f";
 {
   var a = "outer a";
   var b = "outer b";
@@ -9,6 +10,7 @@ var c = "global c";
     print a;
     print b;
     print c;
+    print d;
   }
   print a;
   print b;

--- a/tools/GenerateAst.go
+++ b/tools/GenerateAst.go
@@ -6,6 +6,12 @@ import (
 	"strings"
 )
 
+type Ast struct {
+	types       []string
+	base_name   string
+	return_type string //Is there a way to use type parameters here?
+}
+
 var exprTypes = []string{
 	"Ternary : Operator token.Token, First Expr, Second Expr, Third Expr",
 	"Assign : Name token.Token, Value Expr",
@@ -26,7 +32,19 @@ var stmtTypes = []string{
 const EXPR string = "Expr"
 const STMT string = "Stmt"
 
+var EXPR_AST = Ast{
+	types:       exprTypes,
+	base_name:   "Expr",
+	return_type: "any, error",
+}
+var STMT_AST = Ast{
+	types:       stmtTypes,
+	base_name:   "Stmt",
+	return_type: "error",
+}
+
 func main() {
+
 	args := os.Args[1:]
 	argCount := len(args)
 
@@ -37,39 +55,33 @@ func main() {
 	}
 	outputDir := args[0]
 
-	defineAst(outputDir, EXPR, exprTypes)
-	defineAst(outputDir, STMT, stmtTypes)
+	defineAst(EXPR_AST, outputDir)
+	defineAst(STMT_AST, outputDir)
 }
 
-func defineAst(outputDir string, baseName string, types []string) {
+func defineAst(ast Ast, outputDir string) {
 
-	path := outputDir + "/" + baseName + ".go"
+	path := outputDir + "/" + ast.base_name + ".go"
 	var b strings.Builder
 
 	fmt.Fprintln(&b, "package ast")
 	fmt.Fprintln(&b, "")
-	defineImports(&b, baseName)
+	defineImports(&b, ast)
 
-	fmt.Fprintf(&b, "type %s interface {\n", baseName)
-	fmt.Fprintf(&b, "	Accept(visitor %sVisitor) (any, error)", baseName)
+	fmt.Fprintf(&b, "type %s interface {\n", ast.base_name)
+	fmt.Fprintf(&b, "	Accept(visitor %sVisitor) (%s)", ast.base_name, ast.return_type)
 	fmt.Fprintln(&b, "}")
 	fmt.Fprintln(&b, "")
 
-	defineVisitor(&b, baseName, types)
-
-	for _, v := range types {
-		splits := strings.Split(v, ":")
-		structName := strings.TrimSpace(splits[0])
-		fields := strings.TrimSpace(splits[1])
-		defineType(&b, baseName, structName, fields)
-	}
+	defineVisitor(&b, ast)
+	defineTypes(&b, ast)
 
 	saveFile(path, b)
 
 }
 
-func defineImports(b *strings.Builder, baseName string) {
-	switch baseName {
+func defineImports(b *strings.Builder, ast Ast) {
+	switch ast.base_name {
 	case EXPR:
 		fallthrough
 	case STMT:
@@ -79,21 +91,30 @@ func defineImports(b *strings.Builder, baseName string) {
 	}
 }
 
-func defineVisitor(b *strings.Builder, baseName string, types []string) {
+func defineVisitor(b *strings.Builder, ast Ast) {
 
-	fmt.Fprintf(b, "type %sVisitor interface {\n", baseName)
-	for _, v := range types {
+	fmt.Fprintf(b, "type %sVisitor interface {\n", ast.base_name)
+	for _, v := range ast.types {
 		splits := strings.Split(v, ":")
 		structName := strings.TrimSpace(splits[0])
-		fmt.Fprintf(b, "	Visit%s(%s *%s%s) (any, error)\n", structName, strings.ToLower(baseName), structName, baseName)
+		fmt.Fprintf(b, "	Visit%s(%s *%s%s) (%s)\n", structName, strings.ToLower(ast.base_name), structName, ast.base_name, ast.return_type)
 	}
 	fmt.Fprintln(b, "}")
 	fmt.Fprintln(b, "")
 }
 
-func defineType(b *strings.Builder, baseName string, structName string, fieldList string) {
+func defineTypes(b *strings.Builder, ast Ast) {
+	for _, v := range ast.types {
+		splits := strings.Split(v, ":")
+		structName := strings.TrimSpace(splits[0])
+		fields := strings.TrimSpace(splits[1])
+		defineType(b, ast, structName, fields)
+	}
+}
 
-	fullStructName := structName + baseName
+func defineType(b *strings.Builder, ast Ast, structName string, fieldList string) {
+
+	fullStructName := structName + ast.base_name
 	fmt.Fprintf(b, "type %s struct {\n", fullStructName)
 
 	fields := strings.Split(fieldList, ", ")
@@ -107,7 +128,7 @@ func defineType(b *strings.Builder, baseName string, structName string, fieldLis
 	fmt.Fprintln(b, "}")
 	fmt.Fprintln(b, "")
 
-	fmt.Fprintf(b, "func (e *%s) Accept(visitor %sVisitor) (any, error) {\n", fullStructName, baseName)
+	fmt.Fprintf(b, "func (e *%s) Accept(visitor %sVisitor) (%s) {\n", fullStructName, ast.base_name, ast.return_type)
 	fmt.Fprintf(b, "	return visitor.Visit%s(e)\n", structName)
 	fmt.Fprintln(b, "}")
 	fmt.Fprintln(b, "")


### PR DESCRIPTION
The ExprVisitor and StmtVisitor are both created from the AstGenerator. However they have some different needs, so I made the generator more robust by defining an Ast type that can distinguish the differing needs from different ASTs, and the generator will handle the differences in the instances of those types.

One new generator feature is custom return types on a per Ast basis. With this, the StmtVisitor now only returns an error rather than any, error. Where the any was always nil