### PR TITLE
Control flow

### DIFF
--- a/ast/Expr.go
+++ b/ast/Expr.go
@@ -12,6 +12,7 @@ type ExprVisitor interface {
 	VisitBinary(expr *BinaryExpr) (any, error)
 	VisitGrouping(expr *GroupingExpr) (any, error)
 	VisitLiteral(expr *LiteralExpr) (any, error)
+	VisitLogical(expr *LogicalExpr) (any, error)
 	VisitUnary(expr *UnaryExpr) (any, error)
 	VisitVariable(expr *VariableExpr) (any, error)
 }
@@ -60,6 +61,16 @@ type LiteralExpr struct {
 
 func (e *LiteralExpr) Accept(visitor ExprVisitor) (any, error) {
 	return visitor.VisitLiteral(e)
+}
+
+type LogicalExpr struct {
+	Left     Expr
+	Operator token.Token
+	Right    Expr
+}
+
+func (e *LogicalExpr) Accept(visitor ExprVisitor) (any, error) {
+	return visitor.VisitLogical(e)
 }
 
 type UnaryExpr struct {

--- a/ast/Stmt.go
+++ b/ast/Stmt.go
@@ -12,6 +12,7 @@ type StmtVisitor interface {
 	VisitIf(stmt *IfStmt) (any, error)
 	VisitPrint(stmt *PrintStmt) (any, error)
 	VisitVar(stmt *VarStmt) (any, error)
+	VisitWhile(stmt *WhileStmt) (any, error)
 }
 
 type BlockStmt struct {
@@ -55,4 +56,13 @@ type VarStmt struct {
 
 func (e *VarStmt) Accept(visitor StmtVisitor) (any, error) {
 	return visitor.VisitVar(e)
+}
+
+type WhileStmt struct {
+	Condition Expr
+	Body      Stmt
+}
+
+func (e *WhileStmt) Accept(visitor StmtVisitor) (any, error) {
+	return visitor.VisitWhile(e)
 }

--- a/ast/Stmt.go
+++ b/ast/Stmt.go
@@ -9,6 +9,7 @@ type Stmt interface {
 type StmtVisitor interface {
 	VisitBlock(stmt *BlockStmt) (any, error)
 	VisitExpression(stmt *ExpressionStmt) (any, error)
+	VisitIf(stmt *IfStmt) (any, error)
 	VisitPrint(stmt *PrintStmt) (any, error)
 	VisitVar(stmt *VarStmt) (any, error)
 }
@@ -27,6 +28,16 @@ type ExpressionStmt struct {
 
 func (e *ExpressionStmt) Accept(visitor StmtVisitor) (any, error) {
 	return visitor.VisitExpression(e)
+}
+
+type IfStmt struct {
+	Condition  Expr
+	ThenBranch Stmt
+	ElseBranch Stmt
+}
+
+func (e *IfStmt) Accept(visitor StmtVisitor) (any, error) {
+	return visitor.VisitIf(e)
 }
 
 type PrintStmt struct {

--- a/environment/Environment.go
+++ b/environment/Environment.go
@@ -4,6 +4,7 @@ import (
 	glox_error "dsoechting/glox/error"
 	"dsoechting/glox/token"
 	"fmt"
+	"strings"
 )
 
 type Token = token.Token
@@ -59,8 +60,27 @@ func (e *Environment) Assign(name Token, value any) error {
 		encloseErr := e.enclosing.Assign(name, value)
 		if encloseErr != nil {
 			return encloseErr
+		} else {
+			return nil
 		}
 
 	}
 	return glox_error.Create(name.Line, "", fmt.Sprintf("Undefined variable '%v'.", name.Lexeme))
+}
+
+func (e *Environment) String() string {
+	var sb strings.Builder
+	sb.WriteString("----------")
+	sb.WriteString("Current Env:\n")
+	helper(&sb, e)
+	sb.WriteString("----------")
+	return sb.String()
+}
+
+func helper(sb *strings.Builder, env *Environment) {
+	sb.WriteString(fmt.Sprintln(env.values))
+	if env.enclosing != nil {
+		sb.WriteString("Found Enclosing\n")
+		helper(sb, env.enclosing)
+	}
 }

--- a/fib.glox
+++ b/fib.glox
@@ -1,0 +1,8 @@
+var a = 0;
+var temp;
+
+for (var b = 1; a < 10000; b = temp + b) {
+  print a;
+  temp = a;
+  a = b;
+}

--- a/interpret/Interpreter.go
+++ b/interpret/Interpreter.go
@@ -14,6 +14,7 @@ import (
 type Environment = environment.Environment
 type Stmt = ast.Stmt
 type ExpressionStmt = ast.ExpressionStmt
+type IfStmt = ast.IfStmt
 type PrintStmt = ast.PrintStmt
 type VarStmt = ast.VarStmt
 type BlockStmt = ast.BlockStmt
@@ -68,6 +69,19 @@ func (i *Interpreter) VisitPrint(stmt *PrintStmt) (any, error) {
 	}
 	fmt.Println(stringify(value))
 	//Don't print in REPL
+	return "", nil
+}
+
+func (i *Interpreter) VisitIf(stmt *IfStmt) (any, error) {
+	cond, condErr := stmt.Condition.Accept(i)
+	if condErr != nil {
+		return nil, condErr
+	}
+	if isTruthy(cond) {
+		return i.execute(stmt.ThenBranch)
+	} else if stmt.ElseBranch != nil {
+		return i.execute(stmt.ElseBranch)
+	}
 	return "", nil
 }
 

--- a/interpret/Interpreter.go
+++ b/interpret/Interpreter.go
@@ -16,6 +16,7 @@ type Stmt = ast.Stmt
 type ExpressionStmt = ast.ExpressionStmt
 type IfStmt = ast.IfStmt
 type PrintStmt = ast.PrintStmt
+type WhileStmt = ast.WhileStmt
 type VarStmt = ast.VarStmt
 type BlockStmt = ast.BlockStmt
 type Expr = ast.Expr
@@ -70,6 +71,22 @@ func (i *Interpreter) VisitPrint(stmt *PrintStmt) (any, error) {
 	}
 	fmt.Println(stringify(value))
 	//Don't print in REPL
+	return "", nil
+}
+
+func (i *Interpreter) VisitWhile(stmt *WhileStmt) (any, error) {
+	cond, condErr := i.evaluate(stmt.Condition)
+	if condErr != nil {
+		return nil, condErr
+	}
+
+	for isTruthy(cond) {
+		i.execute(stmt.Body)
+		cond, condErr = i.evaluate(stmt.Condition)
+		if condErr != nil {
+			return nil, condErr
+		}
+	}
 	return "", nil
 }
 

--- a/interpret/Interpreter.go
+++ b/interpret/Interpreter.go
@@ -81,7 +81,11 @@ func (i *Interpreter) VisitWhile(stmt *WhileStmt) (any, error) {
 	}
 
 	for isTruthy(cond) {
-		i.execute(stmt.Body)
+		_, error := i.execute(stmt.Body)
+		if error != nil {
+			return nil, error
+		}
+
 		cond, condErr = i.evaluate(stmt.Condition)
 		if condErr != nil {
 			return nil, condErr

--- a/interpret/Interpreter.go
+++ b/interpret/Interpreter.go
@@ -21,6 +21,7 @@ type BlockStmt = ast.BlockStmt
 type Expr = ast.Expr
 type TernaryExpr = ast.TernaryExpr
 type BinaryExpr = ast.BinaryExpr
+type LogicalExpr = ast.LogicalExpr
 type UnaryExpr = ast.UnaryExpr
 type VariableExpr = ast.VariableExpr
 type GroupingExpr = ast.GroupingExpr
@@ -198,6 +199,24 @@ func (i *Interpreter) VisitGrouping(expr *GroupingExpr) (any, error) {
 
 func (i *Interpreter) VisitLiteral(expr *LiteralExpr) (any, error) {
 	return expr.Value, nil
+}
+
+func (i *Interpreter) VisitLogical(expr *LogicalExpr) (any, error) {
+	left, leftErr := i.evaluate(expr.Left)
+	if leftErr != nil {
+		return nil, leftErr
+	}
+
+	if expr.Operator.TokenType == token.OR {
+		if isTruthy(left) {
+			return left, nil
+		}
+	} else {
+		if !isTruthy(left) {
+			return left, nil
+		}
+	}
+	return i.evaluate(expr.Right)
 }
 
 func (i *Interpreter) VisitUnary(expr *UnaryExpr) (any, error) {

--- a/loop.glox
+++ b/loop.glox
@@ -1,0 +1,5 @@
+var i = 0;
+while (i < 3) {
+  print i;
+  i = i + 1;
+}

--- a/parse/Parser.go
+++ b/parse/Parser.go
@@ -9,6 +9,7 @@ import (
 
 type Expr = ast.Expr
 type Stmt = ast.Stmt
+type WhileStmt = ast.WhileStmt
 type VarStmt = ast.VarStmt
 type TernaryExpr = ast.TernaryExpr
 type BinaryExpr = ast.BinaryExpr
@@ -71,6 +72,9 @@ func (p *Parser) statement() (Stmt, error) {
 	}
 	if p.match(token.PRINT) {
 		return p.printStatement()
+	}
+	if p.match(token.WHILE) {
+		return p.whileStatement()
 	}
 	if p.match(token.LEFT_BRACE) {
 		blockStmts, blockErr := p.block()
@@ -140,6 +144,37 @@ func (p *Parser) printStatement() (Stmt, error) {
 	return &ast.PrintStmt{
 		Expression: value,
 	}, nil
+}
+
+func (p *Parser) whileStatement() (Stmt, error) {
+
+	_, leftParenErr := p.consume(token.LEFT_PAREN, "Expect '(' after 'while'.")
+	if leftParenErr != nil {
+		return nil, leftParenErr
+	}
+
+	// Condition
+	condition, condErr := p.expression()
+	if condErr != nil {
+		return nil, condErr
+	}
+
+	_, rightParenErr := p.consume(token.RIGHT_PAREN, "Expect ')' after while condition.")
+	if rightParenErr != nil {
+		return nil, rightParenErr
+	}
+
+	// Then branch of code
+	body, bodyErr := p.statement()
+	if bodyErr != nil {
+		return nil, bodyErr
+	}
+
+	return &WhileStmt{
+		Condition: condition,
+		Body:      body,
+	}, nil
+
 }
 
 func (p *Parser) varDeclaration() (Stmt, error) {

--- a/parse/Parser.go
+++ b/parse/Parser.go
@@ -65,6 +65,9 @@ func (p *Parser) declaration() (Stmt, error) {
 }
 
 func (p *Parser) statement() (Stmt, error) {
+	if p.match(token.IF) {
+		return p.ifStatement()
+	}
 	if p.match(token.PRINT) {
 		return p.printStatement()
 	}
@@ -79,6 +82,47 @@ func (p *Parser) statement() (Stmt, error) {
 		}, nil
 	}
 	return p.expressionStatement()
+}
+
+func (p *Parser) ifStatement() (Stmt, error) {
+
+	_, leftParenErr := p.consume(token.LEFT_PAREN, "Expect '(' after 'if'.")
+	if leftParenErr != nil {
+		return nil, leftParenErr
+	}
+
+	// Condition
+	condition, condErr := p.expression()
+	if condErr != nil {
+		return nil, condErr
+	}
+
+	_, rightParenErr := p.consume(token.RIGHT_PAREN, "Expect ')' after if condition.")
+	if rightParenErr != nil {
+		return nil, rightParenErr
+	}
+
+	// Then branch of code
+	thenBranch, thenBranchErr := p.statement()
+	if thenBranchErr != nil {
+		return nil, thenBranchErr
+	}
+
+	// Else block if present
+	var maybeElseBranch Stmt
+	if p.match(token.ELSE) {
+		elseBranch, elseBranchErr := p.statement()
+		if elseBranchErr != nil {
+			return nil, elseBranchErr
+		}
+		maybeElseBranch = elseBranch
+	}
+	return &ast.IfStmt{
+		Condition:  condition,
+		ThenBranch: thenBranch,
+		// Possibly nil
+		ElseBranch: maybeElseBranch,
+	}, nil
 }
 
 func (p *Parser) printStatement() (Stmt, error) {

--- a/temp.glox
+++ b/temp.glox
@@ -7,7 +7,9 @@ if (4 > 11) {
   print d;
   print d;
 } else {
-  print "elseeee";
+  var a = "else statement scope a";
+  print a;
+  "elseeee";
 }
 {
   var a = "outer a";

--- a/temp.glox
+++ b/temp.glox
@@ -2,6 +2,13 @@ var a = "global a";
 var b = "global b";
 var c = "global c";
 var d = 4 > 5 ? "t" : "f";
+if (4 > 11) {
+  print d;
+  print d;
+  print d;
+} else {
+  print "elseeee";
+}
 {
   var a = "outer a";
   var b = "outer b";

--- a/tools/GenerateAst.go
+++ b/tools/GenerateAst.go
@@ -29,6 +29,7 @@ var stmtTypes = []string{
 	"If : Condition Expr, ThenBranch Stmt, ElseBranch Stmt",
 	"Print : Expression Expr",
 	"Var : Name token.Token, Initializer Expr",
+	"While : Condition Expr, Body Stmt",
 }
 
 const EXPR string = "Expr"

--- a/tools/GenerateAst.go
+++ b/tools/GenerateAst.go
@@ -25,6 +25,7 @@ var exprTypes = []string{
 var stmtTypes = []string{
 	"Block : Statements []Stmt",
 	"Expression : Expression Expr",
+	"If : Condition Expr, ThenBranch Stmt, ElseBranch Stmt",
 	"Print : Expression Expr",
 	"Var : Name token.Token, Initializer Expr",
 }

--- a/tools/GenerateAst.go
+++ b/tools/GenerateAst.go
@@ -18,6 +18,7 @@ var exprTypes = []string{
 	"Binary : Left Expr, Operator token.Token, Right Expr",
 	"Grouping : Expression Expr",
 	"Literal : Value any",
+	"Logical : Left Expr, Operator token.Token, Right Expr",
 	"Unary : Operator token.Token, Right Expr",
 	"Variable : Name token.Token",
 }


### PR DESCRIPTION
We implemented many different control flow mechanisms.

### Logical AND/OR
We made a new Expr type to represent these unique Binary expressions. The reason for this is because logical operators should be able to implement short circuiting, and the existing binary expressions were not build with short circuiting in mind. So it was easier to separate them in to their own expression type

### If statements
Simple If/Else statements. We parse these statements out, looking for an optionally present else block. These are parsed in to a condition, then block, and else block. The interpreter can then evaluate the condition and then run the correct block of code. Or nothing if there is no else block and the condition is false.

### While loops
These have a similar parsing implementation to if statements. We can find some condition and a body, and then continue to evaluate the body until the condition return false. We keep running the condition after each body execution

###For loops
For loops are mainly just syntactical sugar over while loops. So in this chapter, we "desugared" for loops in to while loops in our parser. This way we could parse for loops in to a while loop representation, and didn't need to add a new statement type or new implementation blocks in our Interpreter. As a by product, I had to fix a hidden bug in the Environment assigning code that did not become present until now.